### PR TITLE
Simplify node monitor

### DIFF
--- a/controllers/estimator_controller.go
+++ b/controllers/estimator_controller.go
@@ -129,12 +129,7 @@ func (r *EstimatorReconciler) reconcileEstimatorNodes(ctx context.Context, estCo
 		case v1beta1.NodeMonitorTypeNone:
 			// return an empty NodeStatus to suppress warnings
 			// NOTE: A Node has an empty NodeStatus by default so this does not change anything, so Predictors should validate the given NodeStatus anyway.
-			nm = &estimator.FakeNodeMonitor{FetchFunc: func(ctx context.Context, base *estimator.NodeStatus) (*estimator.NodeStatus, error) {
-				if base == nil {
-					base = estimator.NewNodeStatus()
-				}
-				return base, nil
-			}}
+			nm = &estimator.FakeNodeMonitor{FetchFunc: func(ctx context.Context, base *estimator.NodeStatus) error { return nil }}
 		case v1beta1.NodeMonitorTypeFake:
 			nm = setupFakeNodeMonitor(r.Client, client.ObjectKeyFromObject(&node))
 		case v1beta1.NodeMonitorTypeIPMIExporter:
@@ -167,7 +162,7 @@ func (r *EstimatorReconciler) reconcileEstimatorNodes(ctx context.Context, estCo
 		}
 		lg.Info(fmt.Sprintf("spec.powerConsumptionPredictor.Type=%v pcp=%+v", pcpType, pcp))
 
-		estNode := estimator.NewNode(name, nm, estConf.Spec.NodeMonitor.RefreshInterval.Duration, pcp)
+		estNode := estimator.NewNode(name, []estimator.NodeMonitor{nm}, estConf.Spec.NodeMonitor.RefreshInterval.Duration, pcp)
 		estNodeList = append(estNodeList, estNode)
 	}
 

--- a/controllers/fake_test.go
+++ b/controllers/fake_test.go
@@ -1,7 +1,6 @@
 package controllers
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -93,88 +92,47 @@ func Test_labelValueInt(t *testing.T) {
 	}
 }
 
-func Test_labelValueJSON(t *testing.T) {
+func Test_labelValueFloat(t *testing.T) {
 	type args struct {
 		m     map[string]string
 		label string
 	}
 	tests := []struct {
-		name     string
-		args     args
-		wantType any
-		wantVal  any
-		wantErr  bool
+		name    string
+		args    args
+		want    float64
+		wantErr bool
 	}{
 		{"not_found", args{
 			m:     map[string]string{},
 			label: "hoge",
-		}, []float64{}, []float64{}, true},
-		{"VF64/empty", args{
-			m: map[string]string{
-				"a": "bd",
-			},
-			label: "a",
-		}, []float64{}, []float64{}, false},
-		{"VF64/normal", args{
-			m: map[string]string{
-				"a": "b1.0p1.5d",
-			},
-			label: "a",
-		}, []float64{}, []float64{1.0, 1.5}, false},
-		{"VF64/wrong1", args{
-			m: map[string]string{
-				"a": "aaaaaaa",
-			},
-			label: "a",
-		}, []float64{}, nil, true},
-		{"VF64/wrong2", args{
-			m: map[string]string{
-				"a": "b__b1.0p1.5d__p__b2.0p2.5d__d",
-			},
-			label: "a",
-		}, []float64{}, nil, true},
-		{"VVF64/empty", args{
-			m: map[string]string{
-				"a": "bd",
-			},
-			label: "a",
-		}, [][]float64{}, [][]float64{}, false},
-		{"VVF64/normal", args{
-			m: map[string]string{
-				"a": "b__b1.0p1.5d__p__b2.0p2.5d__d",
-			},
-			label: "a",
-		}, [][]float64{}, [][]float64{{1.0, 1.5}, {2.0, 2.5}}, false},
-		{"VVF64/wrong", args{
-			m: map[string]string{
-				"a": "b__b1.0p1.5d__p__b2.0p2.5d__d",
-			},
-			label: "a",
-		}, []float64{}, nil, true},
+		}, 0, true},
+		{"1.0", args{
+			m:     map[string]string{"hoge": "1.0"},
+			label: "hoge",
+		}, 1.0, false},
+		{"-1", args{
+			m:     map[string]string{"fuga": "-1"},
+			label: "fuga",
+		}, -1.0, false},
+		{"a", args{
+			m:     map[string]string{"hoge": "a"},
+			label: "hoge",
+		}, 0, true},
+		{"empty_label", args{
+			m:     map[string]string{"": "1.0"},
+			label: "",
+		}, 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var got any
-			var err error
-
-			switch tt.wantType.(type) {
-			case []float64:
-				got, err = labelValueJSON[[]float64](tt.args.m, tt.args.label)
-			case [][]float64:
-				got, err = labelValueJSON[[][]float64](tt.args.m, tt.args.label)
-			default:
-				t.Errorf("got type=%T", tt.wantType)
-			}
-
+			got, err := labelValueFloat(tt.args.m, tt.args.label)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("labelValueJSON() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("labelValueFloat() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			// NOTE: it's hard to compare the returned value in error cases (e.g. any([]float64(nil),) vs. any() )
-			if err == nil {
-				if !reflect.DeepEqual(got, tt.wantVal) {
-					t.Errorf("labelValueJSON() = %v (%T), want %v (%T)", got, got, tt.wantVal, tt.wantVal)
-				}
+			if got != tt.want {
+				t.Errorf("labelValueFloat() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/estimator/client.go
+++ b/pkg/estimator/client.go
@@ -60,7 +60,7 @@ func (c *Client) EstimatePowerConsumption(ctx context.Context, cpuMilli, numWork
 	}
 	switch resp.StatusCode() {
 	case http.StatusOK:
-		// HACK: restore math.Float64 to math.Inf(1) (see also: server.go)
+		// HACK: restore math.MaxFloat64 to math.Inf(1) (see also: server.go)
 		for i := range *resp.JSON200.WattIncreases {
 			if (*resp.JSON200.WattIncreases)[i] == math.MaxFloat64 {
 				(*resp.JSON200.WattIncreases)[i] = math.Inf(1)

--- a/pkg/estimator/node.go
+++ b/pkg/estimator/node.go
@@ -7,73 +7,6 @@ import (
 	"time"
 )
 
-type NodeStatus struct {
-	Timestamp time.Time
-
-	// CPUSockets is the number of sockets the node has.
-	// e.g. 2
-	CPUSockets int
-	// CPUCores is the number of cores per CPU.
-	// e.g. 4
-	CPUCores int
-	// CPUUsages is the list of CPU usages per core.
-	// e.g. [[10.0, 10.0, 10.0, 10.0], [20.0, 20.0, 20.0, 20.0]]
-	CPUUsages [][]float64
-	// CPUTemps is the list of CPU temperatures in Celsius per core.
-	// e.g. [[30.0, 30.0, 30.0, 30.0], [50.0, 50.0, 50.0, 50.0]]
-	CPUTemps [][]float64
-
-	// AmbientSensors is the number of ambient temperature sensors the node has.
-	// e.g. 4
-	AmbientSensors int
-	// AmbientTemps is the list of temperatures in Celsius.
-	// e.g. [20.0, 20.0, 20.0, 20.0]
-	AmbientTemps []float64
-}
-
-func (s *NodeStatus) AverageCPUUsage() (float64, error) {
-	var c int
-	var sum float64
-	for _, temps := range s.CPUUsages {
-		for _, e := range temps {
-			sum += e
-			c++
-		}
-	}
-	if c == 0 {
-		return sum, ErrNodeStatus
-	}
-	return sum / float64(c), nil
-}
-
-func (s *NodeStatus) AverageCPUTemp() (float64, error) {
-	var c int
-	var sum float64
-	for _, temps := range s.CPUTemps {
-		for _, e := range temps {
-			sum += e
-			c++
-		}
-	}
-	if c == 0 {
-		return sum, ErrNodeStatus
-	}
-	return sum / float64(c), nil
-}
-
-func (s *NodeStatus) AverageAmbientTemp() (float64, error) {
-	var c int
-	var sum float64
-	for _, e := range s.AmbientTemps {
-		sum += e
-		c++
-	}
-	if c == 0 {
-		return sum, ErrNodeStatus
-	}
-	return sum / float64(c), nil
-}
-
 type Node struct {
 	Name string
 
@@ -82,7 +15,7 @@ type Node struct {
 
 	monitor    NodeMonitor
 	nmInterval time.Duration
-	status     NodeStatus
+	status     *NodeStatus
 
 	pcPredictor PowerConsumptionPredictor
 }
@@ -90,14 +23,14 @@ type Node struct {
 var _ NodeMonitor = (*Node)(nil)
 var _ PowerConsumptionPredictor = (*Node)(nil)
 
-func (n *Node) FetchStatus(ctx context.Context) (NodeStatus, error) {
+func (n *Node) FetchStatus(ctx context.Context, base *NodeStatus) (*NodeStatus, error) {
 	if n.monitor == nil {
-		return NodeStatus{}, ErrNodeMonitorNotFound
+		return nil, ErrNodeMonitorNotFound
 	}
-	return n.monitor.FetchStatus(ctx)
+	return n.monitor.FetchStatus(ctx, base)
 }
 
-func (n *Node) Predict(ctx context.Context, requestCPUMilli int, status NodeStatus) (watt float64, err error) {
+func (n *Node) Predict(ctx context.Context, requestCPUMilli int, status *NodeStatus) (watt float64, err error) {
 	if n.pcPredictor == nil {
 		return 0.0, ErrPCPredictorNotFound
 	}
@@ -122,7 +55,7 @@ func (n *Node) start() {
 	updateStatus := func() {
 		timeout := n.nmInterval / 2
 		ctx, cncl := context.WithTimeout(context.Background(), timeout)
-		status, err := n.FetchStatus(ctx)
+		status, err := n.FetchStatus(ctx, NewNodeStatus())
 		cncl()
 		if err != nil {
 			lg.Warn().Msgf("could not fetch NodeStatus: %v", err)
@@ -152,9 +85,14 @@ func (n *Node) stop() {
 	close(n.stopCh)
 }
 
-func (n *Node) GetStatus() NodeStatus {
+// GetStatus returns current status of the Node,
+// if Node.status is nil then returns a new empty NodeStatus.
+func (n *Node) GetStatus() *NodeStatus {
 	n.mu.Lock()
 	defer n.mu.Unlock()
+	if n.status == nil {
+		return NewNodeStatus()
+	}
 	return n.status
 }
 

--- a/pkg/estimator/node_monitor.go
+++ b/pkg/estimator/node_monitor.go
@@ -6,18 +6,18 @@ import (
 )
 
 type NodeMonitor interface {
-	FetchStatus(ctx context.Context, base *NodeStatus) (*NodeStatus, error)
+	FetchStatus(ctx context.Context, base *NodeStatus) error
 }
 
 type FakeNodeMonitor struct {
-	FetchFunc func(ctx context.Context, base *NodeStatus) (*NodeStatus, error)
+	FetchFunc func(ctx context.Context, base *NodeStatus) error
 }
 
 var _ NodeMonitor = (*FakeNodeMonitor)(nil)
 
-func (m *FakeNodeMonitor) FetchStatus(ctx context.Context, base *NodeStatus) (*NodeStatus, error) {
+func (m *FakeNodeMonitor) FetchStatus(ctx context.Context, base *NodeStatus) error {
 	if m.FetchFunc == nil {
-		return nil, fmt.Errorf("FetchFunc not set (%w)", ErrNodeMonitor)
+		return fmt.Errorf("FetchFunc not set (%w)", ErrNodeMonitor)
 	}
 	return m.FetchFunc(ctx, base)
 }
@@ -28,7 +28,7 @@ type RedfishNodeMonitor struct {
 
 var _ NodeMonitor = (*RedfishNodeMonitor)(nil)
 
-func (m *RedfishNodeMonitor) FetchStatus(ctx context.Context, base *NodeStatus) (*NodeStatus, error) {
+func (m *RedfishNodeMonitor) FetchStatus(ctx context.Context, base *NodeStatus) error {
 	// TODO
-	return nil, fmt.Errorf("not yet implemented (%w)", ErrNodeMonitor)
+	return fmt.Errorf("not yet implemented (%w)", ErrNodeMonitor)
 }

--- a/pkg/estimator/node_monitor.go
+++ b/pkg/estimator/node_monitor.go
@@ -6,20 +6,20 @@ import (
 )
 
 type NodeMonitor interface {
-	FetchStatus(ctx context.Context) (NodeStatus, error)
+	FetchStatus(ctx context.Context, base *NodeStatus) (*NodeStatus, error)
 }
 
 type FakeNodeMonitor struct {
-	FetchFunc func(ctx context.Context) (NodeStatus, error)
+	FetchFunc func(ctx context.Context, base *NodeStatus) (*NodeStatus, error)
 }
 
 var _ NodeMonitor = (*FakeNodeMonitor)(nil)
 
-func (m *FakeNodeMonitor) FetchStatus(ctx context.Context) (NodeStatus, error) {
+func (m *FakeNodeMonitor) FetchStatus(ctx context.Context, base *NodeStatus) (*NodeStatus, error) {
 	if m.FetchFunc == nil {
-		return NodeStatus{}, fmt.Errorf("FetchFunc not set (%w)", ErrNodeMonitor)
+		return nil, fmt.Errorf("FetchFunc not set (%w)", ErrNodeMonitor)
 	}
-	return m.FetchFunc(ctx)
+	return m.FetchFunc(ctx, base)
 }
 
 type RedfishNodeMonitor struct {
@@ -28,7 +28,7 @@ type RedfishNodeMonitor struct {
 
 var _ NodeMonitor = (*RedfishNodeMonitor)(nil)
 
-func (m *RedfishNodeMonitor) FetchStatus(ctx context.Context) (NodeStatus, error) {
+func (m *RedfishNodeMonitor) FetchStatus(ctx context.Context, base *NodeStatus) (*NodeStatus, error) {
 	// TODO
-	return NodeStatus{}, fmt.Errorf("not yet implemented (%w)", ErrNodeMonitor)
+	return nil, fmt.Errorf("not yet implemented (%w)", ErrNodeMonitor)
 }

--- a/pkg/estimator/node_monitor_test.go
+++ b/pkg/estimator/node_monitor_test.go
@@ -5,49 +5,41 @@ import (
 	"errors"
 	"reflect"
 	"testing"
-	"time"
 )
 
-var testNS1 = NodeStatus{
-	Timestamp:      time.Now(),
-	CPUSockets:     2,
-	CPUCores:       4,
-	CPUUsages:      [][]float64{{10.0, 10.0, 10.0, 10.0}, {10.0, 10.0, 10.0, 10.0}},
-	CPUTemps:       [][]float64{{30.0, 30.0, 30.0, 30.0}, {30.0, 30.0, 30.0, 30.0}},
-	AmbientSensors: 2,
-	AmbientTemps:   []float64{20.0, 20.0},
-}
-
-func getFnCopy(s NodeStatus, err error) func(ctx context.Context) (NodeStatus, error) {
-	return func(_ context.Context) (NodeStatus, error) {
+func getFnCopy(s *NodeStatus, err error) func(ctx context.Context, base *NodeStatus) (*NodeStatus, error) {
+	return func(context.Context, *NodeStatus) (*NodeStatus, error) {
 		return s, err
 	}
 }
 
 func TestFakeNodeMonitor_FetchStatus(t *testing.T) {
+	var testNodeStatus = NewNodeStatus()
+
 	type fields struct {
-		FetchFunc func(ctx context.Context) (NodeStatus, error)
+		FetchFunc func(ctx context.Context, base *NodeStatus) (*NodeStatus, error)
 	}
 	type args struct {
-		ctx context.Context
+		ctx  context.Context
+		base *NodeStatus
 	}
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
-		want    NodeStatus
+		want    *NodeStatus
 		wantErr bool
 	}{
-		{"FetchFunc=nil", fields{nil}, args{context.Background()}, NodeStatus{}, true},
-		{"ok", fields{getFnCopy(testNS1, nil)}, args{context.Background()}, testNS1, false},
-		{"err", fields{getFnCopy(NodeStatus{}, errors.New(""))}, args{context.Background()}, NodeStatus{}, true},
+		{"FetchFunc=nil", fields{nil}, args{context.Background(), nil}, nil, true},
+		{"ok", fields{getFnCopy(testNodeStatus, nil)}, args{context.Background(), testNodeStatus}, testNodeStatus, false},
+		{"err", fields{getFnCopy(nil, errors.New(""))}, args{context.Background(), testNodeStatus}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := &FakeNodeMonitor{
 				FetchFunc: tt.fields.FetchFunc,
 			}
-			got, err := m.FetchStatus(tt.args.ctx)
+			got, err := m.FetchStatus(tt.args.ctx, tt.args.base)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("FakeNodeMonitor.FetchStatus() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/estimator/node_status.go
+++ b/pkg/estimator/node_status.go
@@ -1,0 +1,90 @@
+package estimator
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"sync"
+	"time"
+)
+
+type NodeStatusKey string
+
+type NodeStatus struct {
+	timestamp time.Time
+	data      sync.Map
+}
+
+func NewNodeStatus() *NodeStatus { return &NodeStatus{timestamp: time.Now()} }
+
+func (s *NodeStatus) Timestamp() time.Time { return s.timestamp }
+
+func (s *NodeStatus) Get(k NodeStatusKey) (string, bool) {
+	v, ok := s.data.Load(k)
+	if !ok {
+		return "", false
+	}
+	return v.(string), true
+}
+
+func (s *NodeStatus) Set(k NodeStatusKey, v string) { s.data.Store(k, v) }
+
+func (s *NodeStatus) Delete(k NodeStatusKey) { s.data.Delete(k) }
+
+func (s *NodeStatus) Range(f func(k NodeStatusKey, v string) bool) {
+	s.data.Range(func(kk any, vv any) bool { return f(kk.(NodeStatusKey), vv.(string)) })
+}
+
+const NodeStatusCPUUsage NodeStatusKey = "cpuUsage"
+
+func NodeStatusSetCPUUsage(s *NodeStatus, cpuUsage float64) {
+	s.Set(NodeStatusCPUUsage, strconv.FormatFloat(cpuUsage, 'f', -1, 64))
+}
+
+func NodeStatusGetCPUUsage(s *NodeStatus) (float64, error) {
+	v, ok := s.Get(NodeStatusCPUUsage)
+	if !ok {
+		return -math.MaxFloat64, fmt.Errorf("key=%+v not found", NodeStatusCPUUsage)
+	}
+	vv, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return -math.MaxFloat64, err
+	}
+	return vv, nil
+}
+
+const NodeStatusAmbientTemp NodeStatusKey = "ambientTemp"
+
+func NodeStatusSetAmbientTemp(s *NodeStatus, ambientTemp float64) {
+	s.Set(NodeStatusAmbientTemp, strconv.FormatFloat(ambientTemp, 'f', -1, 64))
+}
+
+func NodeStatusGetAmbientTemp(s *NodeStatus) (float64, error) {
+	v, ok := s.Get(NodeStatusAmbientTemp)
+	if !ok {
+		return -math.MaxFloat64, fmt.Errorf("key=%+v not found", NodeStatusAmbientTemp)
+	}
+	vv, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return -math.MaxFloat64, err
+	}
+	return vv, nil
+}
+
+const NodeStatusStaticPressureDiff NodeStatusKey = "staticPressureDiff"
+
+func NodeStatusSetStaticPressureDiff(s *NodeStatus, spd float64) {
+	s.Set(NodeStatusStaticPressureDiff, strconv.FormatFloat(spd, 'f', -1, 64))
+}
+
+func NodeStatusGetStaticPressureDiff(s *NodeStatus) (float64, error) {
+	v, ok := s.Get(NodeStatusStaticPressureDiff)
+	if !ok {
+		return -math.MaxFloat64, fmt.Errorf("key=%+v not found", NodeStatusStaticPressureDiff)
+	}
+	vv, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return -math.MaxFloat64, err
+	}
+	return vv, nil
+}

--- a/pkg/estimator/node_status_test.go
+++ b/pkg/estimator/node_status_test.go
@@ -1,0 +1,74 @@
+package estimator
+
+import (
+	"testing"
+)
+
+func TestNodeStatusGetCPUUsage(t *testing.T) {
+	tests := []struct {
+		name string
+		want float64
+	}{
+		{"10.0", 10.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewNodeStatus()
+			NodeStatusSetCPUUsage(s, tt.want)
+			got, err := NodeStatusGetCPUUsage(s)
+			if err != nil {
+				t.Errorf("NodeStatusGetCPUUsage() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NodeStatusGetCPUUsage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeStatusGetAmbientTemp(t *testing.T) {
+	tests := []struct {
+		name string
+		want float64
+	}{
+		{"10.0", 10.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewNodeStatus()
+			NodeStatusSetAmbientTemp(s, tt.want)
+			got, err := NodeStatusGetAmbientTemp(s)
+			if err != nil {
+				t.Errorf("NodeStatusGetAmbientTemp() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NodeStatusGetAmbientTemp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNodeStatusGetStaticPressureDiff(t *testing.T) {
+	tests := []struct {
+		name string
+		want float64
+	}{
+		{"10.0", 10.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewNodeStatus()
+			NodeStatusSetStaticPressureDiff(s, tt.want)
+			got, err := NodeStatusGetStaticPressureDiff(s)
+			if err != nil {
+				t.Errorf("NodeStatusGetStaticPressureDiff() error = %v", err)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("NodeStatusGetStaticPressureDiff() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/estimator/node_test.go
+++ b/pkg/estimator/node_test.go
@@ -7,132 +7,6 @@ import (
 	"time"
 )
 
-func TestNodeStatus_AverageCPUUsage(t *testing.T) {
-	type fields struct {
-		CPUSockets     int
-		CPUCores       int
-		CPUCoreUsages  [][]float64
-		CPUCoreTemps   [][]float64
-		AmbientSensors int
-		AmbientTemps   []float64
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    float64
-		wantErr bool
-	}{
-		{"err_nil", fields{0, 0, nil, nil, 0, nil}, 0.0, true},
-		{"err_0cpu0core", fields{0, 0, [][]float64{}, nil, 0, nil}, 0.0, true},
-		{"1cpu8core", fields{0, 0, [][]float64{{20.0, 20.0, 30.0, 30.0, 40.0, 40.0, 50.0, 50.0}}, nil, 0, nil}, 35.0, false},
-		{"4cpu8core", fields{0, 0, [][]float64{{20.0, 20.0}, {30.0, 30.0}, {40.0, 40.0}, {50.0, 50.0}}, nil, 0, nil}, 35.0, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &NodeStatus{
-				CPUSockets:     tt.fields.CPUSockets,
-				CPUCores:       tt.fields.CPUCores,
-				CPUUsages:      tt.fields.CPUCoreUsages,
-				CPUTemps:       tt.fields.CPUCoreTemps,
-				AmbientSensors: tt.fields.AmbientSensors,
-				AmbientTemps:   tt.fields.AmbientTemps,
-			}
-			got, err := s.AverageCPUUsage()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeStatus.AverageCPUUsage() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("NodeStatus.AverageCPUUsage() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestNodeStatus_AverageCPUTemp(t *testing.T) {
-	type fields struct {
-		CPUSockets     int
-		CPUCores       int
-		CPUCoreUsages  [][]float64
-		CPUCoreTemps   [][]float64
-		AmbientSensors int
-		AmbientTemps   []float64
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    float64
-		wantErr bool
-	}{
-		{"err_nil", fields{0, 0, nil, nil, 0, nil}, 0.0, true},
-		{"err_0cpu0core", fields{0, 0, nil, [][]float64{}, 0, nil}, 0.0, true},
-		{"1cpu8core", fields{0, 0, nil, [][]float64{{20.0, 20.0, 30.0, 30.0, 40.0, 40.0, 50.0, 50.0}}, 0, nil}, 35.0, false},
-		{"4cpu8core", fields{0, 0, nil, [][]float64{{20.0, 20.0}, {30.0, 30.0}, {40.0, 40.0}, {50.0, 50.0}}, 0, nil}, 35.0, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &NodeStatus{
-				CPUSockets:     tt.fields.CPUSockets,
-				CPUCores:       tt.fields.CPUCores,
-				CPUUsages:      tt.fields.CPUCoreUsages,
-				CPUTemps:       tt.fields.CPUCoreTemps,
-				AmbientSensors: tt.fields.AmbientSensors,
-				AmbientTemps:   tt.fields.AmbientTemps,
-			}
-			got, err := s.AverageCPUTemp()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeStatus.AverageCPUTemp() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("NodeStatus.AverageCPUTemp() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestNodeStatus_AverageAmbientTemp(t *testing.T) {
-	type fields struct {
-		CPUSockets     int
-		CPUCores       int
-		CPUCoreUsages  [][]float64
-		CPUCoreTemps   [][]float64
-		AmbientSensors int
-		AmbientTemps   []float64
-	}
-	tests := []struct {
-		name    string
-		fields  fields
-		want    float64
-		wantErr bool
-	}{
-		{"err_nil", fields{0, 0, nil, nil, 0, nil}, 0.0, true},
-		{"err_0sensor", fields{0, 0, nil, nil, 0, []float64{}}, 0.0, true},
-		{"1sensor", fields{0, 0, nil, nil, 0, []float64{35.0}}, 35.0, false},
-		{"4sensor", fields{0, 0, nil, nil, 0, []float64{20.0, 30.0, 40.0, 50.0}}, 35.0, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			s := &NodeStatus{
-				CPUSockets:     tt.fields.CPUSockets,
-				CPUCores:       tt.fields.CPUCores,
-				CPUUsages:      tt.fields.CPUCoreUsages,
-				CPUTemps:       tt.fields.CPUCoreTemps,
-				AmbientSensors: tt.fields.AmbientSensors,
-				AmbientTemps:   tt.fields.AmbientTemps,
-			}
-			got, err := s.AverageAmbientTemp()
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NodeStatus.AverageAmbientTemp() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("NodeStatus.AverageAmbientTemp() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestNodes_Len(t *testing.T) {
 	type op int
 	const (
@@ -193,28 +67,29 @@ func TestNodes_Len(t *testing.T) {
 }
 
 func TestNode_FetchStatus(t *testing.T) {
+	testNodeStatus := NewNodeStatus()
 	tests := []struct {
 		name    string
 		node    *Node
-		want    NodeStatus
+		want    *NodeStatus
 		wantErr bool
 	}{
 		{"nm==nil", &Node{
 			Name:    "n1",
 			monitor: nil,
-		}, NodeStatus{}, true},
+		}, nil, true},
 		{"nm!=nil", &Node{
 			Name:    "n1",
-			monitor: &FakeNodeMonitor{FetchFunc: func(context.Context) (NodeStatus, error) { return testNS1, nil }},
-		}, testNS1, false},
+			monitor: &FakeNodeMonitor{FetchFunc: func(context.Context, *NodeStatus) (*NodeStatus, error) { return testNodeStatus, nil }},
+		}, testNodeStatus, false},
 		{"failed", &Node{
 			Name:    "n1",
-			monitor: &FakeNodeMonitor{FetchFunc: func(context.Context) (NodeStatus, error) { return NodeStatus{}, ErrNodeMonitor }},
-		}, NodeStatus{}, true},
+			monitor: &FakeNodeMonitor{FetchFunc: func(context.Context, *NodeStatus) (*NodeStatus, error) { return nil, ErrNodeMonitor }},
+		}, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.node.FetchStatus(context.Background())
+			got, err := tt.node.FetchStatus(context.Background(), NewNodeStatus())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Node.FetchStatus() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -229,7 +104,7 @@ func TestNode_FetchStatus(t *testing.T) {
 func TestNode_Predict(t *testing.T) {
 	type args struct {
 		requestCPUMilli int
-		status          NodeStatus
+		status          *NodeStatus
 	}
 	tests := []struct {
 		name     string
@@ -241,15 +116,15 @@ func TestNode_Predict(t *testing.T) {
 		{"pcp==nil", &Node{
 			Name:        "n1",
 			pcPredictor: nil,
-		}, args{2000, testNS1}, 0.0, true},
+		}, args{2000, newNodeStatus(20.0, 20.0, 0.0)}, 0.0, true},
 		{"pcp!=nil", &Node{
 			Name:        "n1",
 			pcPredictor: &FakePCPredictor{PredictFunc: PredictPCFnDummy},
-		}, args{2000, testNS1}, 50.0, false},
+		}, args{2000, newNodeStatus(20.0, 10.0, 0.0)}, 50.0, false},
 		{"failed", &Node{
 			Name:        "n1",
-			pcPredictor: &FakePCPredictor{PredictFunc: func(context.Context, int, NodeStatus) (float64, error) { return 0.0, ErrPCPredictor }},
-		}, args{2000, testNS1}, 0.0, true},
+			pcPredictor: &FakePCPredictor{PredictFunc: func(context.Context, int, *NodeStatus) (float64, error) { return 0.0, ErrPCPredictor }},
+		}, args{2000, newNodeStatus(20.0, 20.0, 0.0)}, 0.0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/estimator/predictor_pc.go
+++ b/pkg/estimator/predictor_pc.go
@@ -6,33 +6,33 @@ import (
 )
 
 type PowerConsumptionPredictor interface {
-	Predict(ctx context.Context, requestCPUMilli int, status NodeStatus) (watt float64, err error)
+	Predict(ctx context.Context, requestCPUMilli int, status *NodeStatus) (watt float64, err error)
 }
 
 type FakePCPredictor struct {
-	PredictFunc func(ctx context.Context, requestCPUMilli int, status NodeStatus) (watt float64, err error)
+	PredictFunc func(ctx context.Context, requestCPUMilli int, status *NodeStatus) (watt float64, err error)
 }
 
 var _ PowerConsumptionPredictor = (*FakePCPredictor)(nil)
 
-func (p *FakePCPredictor) Predict(ctx context.Context, requestCPUMilli int, status NodeStatus) (watt float64, err error) {
+func (p *FakePCPredictor) Predict(ctx context.Context, requestCPUMilli int, status *NodeStatus) (watt float64, err error) {
 	if p.PredictFunc == nil {
 		return 0.0, fmt.Errorf("PredictFunc not set (%w)", ErrPCPredictor)
 	}
 	return p.PredictFunc(ctx, requestCPUMilli, status)
 }
 
-// PredictPCFnDummy returns ( mCPU/100 + avg(CPUUsage) + avg(AmbientTemp) )
-func PredictPCFnDummy(_ context.Context, mcpu int, status NodeStatus) (float64, error) {
-	aat, err := status.AverageAmbientTemp()
+// PredictPCFnDummy returns ( mCPU/100 + CPUUsage + AmbientTemp )
+func PredictPCFnDummy(_ context.Context, mcpu int, status *NodeStatus) (float64, error) {
+	at, err := NodeStatusGetAmbientTemp(status)
 	if err != nil {
 		return 0.0, err
 	}
-	acu, err := status.AverageCPUUsage()
+	cu, err := NodeStatusGetCPUUsage(status)
 	if err != nil {
 		return 0.0, err
 	}
-	w := float64(mcpu)/100 + aat + acu
+	w := float64(mcpu)/100 + at + cu
 	return w, nil
 }
 
@@ -42,7 +42,7 @@ type MLServerPCPredictor struct {
 
 var _ PowerConsumptionPredictor = (*MLServerPCPredictor)(nil)
 
-func (p *MLServerPCPredictor) Predict(ctx context.Context, requestCPUMilli int, status NodeStatus) (watt float64, err error) {
+func (p *MLServerPCPredictor) Predict(ctx context.Context, requestCPUMilli int, status *NodeStatus) (watt float64, err error) {
 	// TODO
 	return 0.0, fmt.Errorf("not yet implemented (%w)", ErrPCPredictor)
 }

--- a/pkg/estimator/predictor_pc_test.go
+++ b/pkg/estimator/predictor_pc_test.go
@@ -5,14 +5,22 @@ import (
 	"testing"
 )
 
+func newNodeStatus(cpuUsage, ambientTemp, staticPressureDiff float64) *NodeStatus {
+	v := NewNodeStatus()
+	NodeStatusSetCPUUsage(v, cpuUsage)
+	NodeStatusSetAmbientTemp(v, ambientTemp)
+	NodeStatusSetStaticPressureDiff(v, staticPressureDiff)
+	return v
+}
+
 func TestFakePCPredictor_Predict(t *testing.T) {
 	type fields struct {
-		PredictFunc func(ctx context.Context, requestCPUMilli int, status NodeStatus) (watt float64, err error)
+		PredictFunc func(ctx context.Context, requestCPUMilli int, status *NodeStatus) (watt float64, err error)
 	}
 	type args struct {
 		ctx             context.Context
 		requestCPUMilli int
-		status          NodeStatus
+		status          *NodeStatus
 	}
 	tests := []struct {
 		name     string
@@ -21,19 +29,10 @@ func TestFakePCPredictor_Predict(t *testing.T) {
 		wantWatt float64
 		wantErr  bool
 	}{
-		{"PredictFunc=nil", fields{nil}, args{context.Background(), 2000, NodeStatus{
-			CPUUsages:    [][]float64{{30.0}},
-			AmbientTemps: []float64{20.0},
-		}}, 0.0, true},
-		{"70", fields{PredictPCFnDummy}, args{context.Background(), 2000, NodeStatus{
-			CPUUsages:    [][]float64{{30.0}},
-			AmbientTemps: []float64{20.0},
-		}}, 70.0, false},
-		{"80", fields{PredictPCFnDummy}, args{context.Background(), 2000, NodeStatus{
-			CPUUsages:    [][]float64{{35.0}},
-			AmbientTemps: []float64{25.0},
-		}}, 80.0, false},
-		{"err", fields{PredictPCFnDummy}, args{context.Background(), 2000, NodeStatus{}}, 0.0, true},
+		{"PredictFunc=nil", fields{nil}, args{context.Background(), 2000, newNodeStatus(30.0, 20.0, 0.0)}, 0.0, true},
+		{"70", fields{PredictPCFnDummy}, args{context.Background(), 2000, newNodeStatus(30.0, 20.0, 0.0)}, 70.0, false},
+		{"80", fields{PredictPCFnDummy}, args{context.Background(), 2000, newNodeStatus(35.0, 25.0, 0.0)}, 80.0, false},
+		{"err", fields{PredictPCFnDummy}, args{context.Background(), 2000, NewNodeStatus()}, 0.0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Restruct `NodeStatus`

Before

```go
type NodeStatus struct {
	Timestamp time.Time

	// CPUSockets is the number of sockets the node has.
	// e.g. 2
	CPUSockets int
	// CPUCores is the number of cores per CPU.
	// e.g. 4
	CPUCores int
	// CPUUsages is the list of CPU usages per core.
	// e.g. [[10.0, 10.0, 10.0, 10.0], [20.0, 20.0, 20.0, 20.0]]
	CPUUsages [][]float64
	// CPUTemps is the list of CPU temperatures in Celsius per core.
	// e.g. [[30.0, 30.0, 30.0, 30.0], [50.0, 50.0, 50.0, 50.0]]
	CPUTemps [][]float64

	// AmbientSensors is the number of ambient temperature sensors the node has.
	// e.g. 4
	AmbientSensors int
	// AmbientTemps is the list of temperatures in Celsius.
	// e.g. [20.0, 20.0, 20.0, 20.0]
	AmbientTemps []float64
}
```

After

```go
type NodeStatusKey string

type NodeStatus struct {
	timestamp time.Time
	data      sync.Map
}

const NodeStatusCPUUsage NodeStatusKey = "cpuUsage"
const NodeStatusAmbientTemp NodeStatusKey = "ambientTemp"
const NodeStatusStaticPressureDiff NodeStatusKey = "staticPressureDiff"
```

## Apply multiple `NodeMonitor`

```diff
  type Node struct {
  	Name string
  
  	mu     sync.Mutex
  	stopCh chan struct{}
  
- 	monitor    NodeMonitor
+ 	monitors   []NodeMonitor
  	nmInterval time.Duration
- 	status     NodeStatus
+ 	status     *NodeStatus

  	pcPredictor PowerConsumptionPredictor
  }
```
